### PR TITLE
Fix initial text mismatch

### DIFF
--- a/TypingPall/Utils/String+Utils.swift
+++ b/TypingPall/Utils/String+Utils.swift
@@ -11,7 +11,7 @@ extension String {
     func extractMismatchedRange(comparedTo placeholder: String) -> NSRange? {
         guard !isEmpty else { return nil }
         let commonPrefix = self.commonPrefix(with: placeholder, options: .literal)
-        guard commonPrefix.count < self.count, commonPrefix.count >= 1 else { return nil }
+        guard commonPrefix.count < self.count else { return nil }
         return NSRange(location: commonPrefix.count, length: self.count - commonPrefix.count)
     }
 }

--- a/TypingPall/Views/TypingEditor.swift
+++ b/TypingPall/Views/TypingEditor.swift
@@ -77,8 +77,11 @@ struct TypingEditor: NSViewRepresentable {
             textView.setTextColor(.systemGreen, range: NSMakeRange(0, textView.string.count))
             return
         }
+        
+        if range.location > 1 {
+            textView.setTextColor(.systemGreen, range: NSMakeRange(0,  range.location - 1))
+        }
 
-        textView.setTextColor(.systemGreen, range: NSMakeRange(0,  range.location - 1))
         textView.setTextColor(.red, range: range)
     }
 }

--- a/TypingPallTests/StringExtensionTests.swift
+++ b/TypingPallTests/StringExtensionTests.swift
@@ -78,8 +78,20 @@ class StringExtensionTests: XCTestCase {
         // When: extractMismatchedRange is called
         let range = stringA.extractMismatchedRange(comparedTo: stringB)
 
-        // Then: The result should be nil
-        XCTAssertNil(range)
+        // Then: The result all string A is mismatched
+        XCTAssertEqual(range, NSRange(location: 0, length: 13))
+    }
+
+    func testExtractMismatchedRange_WhenStringBIsTotallyMismatch() {
+        // Given: String B is empty
+        let stringA = "Hello, World!"
+        let stringB = "WFDSFDHSJ"
+
+        // When: extractMismatchedRange is called
+        let range = stringA.extractMismatchedRange(comparedTo: stringB)
+
+        // Then: The result all string A is mismatched compare to String B
+        XCTAssertEqual(range, NSRange(location: 0, length: 13))
     }
 }
 


### PR DESCRIPTION
# Why

As per ticket above, we need to fix the defect in this release.

# How

Changes included in this pull request:
- Fix initial mismatch


# Screenshots


<img width="507" alt="Screenshot 2023-07-25 at 09 10 56" src="https://github.com/Mieraidihaimu/TypingPall/assets/10674364/c22214be-e561-44a6-b313-d47ce1a92c4c">


