### PR TITLE
Extract all the state objects into a viewModel, so that it doesn't bloated in UI file

### DIFF
--- a/TypingPall.xcodeproj/project.pbxproj
+++ b/TypingPall.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7D76E1952A6FBC7F00D76E59 /* TypingScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D76E1942A6FBC7F00D76E59 /* TypingScreenViewModel.swift */; };
 		7DCAA2772A5F33D600AFC118 /* TypingPallApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAA2762A5F33D600AFC118 /* TypingPallApp.swift */; };
 		7DCAA27B2A5F33D700AFC118 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DCAA27A2A5F33D700AFC118 /* Assets.xcassets */; };
 		7DCAA27E2A5F33D700AFC118 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DCAA27D2A5F33D700AFC118 /* Preview Assets.xcassets */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		7D76E1942A6FBC7F00D76E59 /* TypingScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingScreenViewModel.swift; sourceTree = "<group>"; };
 		7DCAA2732A5F33D600AFC118 /* TypingPall.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TypingPall.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DCAA2762A5F33D600AFC118 /* TypingPallApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingPallApp.swift; sourceTree = "<group>"; };
 		7DCAA27A2A5F33D700AFC118 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -83,6 +85,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7D76E1932A6FBC6E00D76E59 /* TypingScreenView */ = {
+			isa = PBXGroup;
+			children = (
+				7DCAA2A72A5F340100AFC118 /* TypingScreenView.swift */,
+				7D76E1942A6FBC7F00D76E59 /* TypingScreenViewModel.swift */,
+			);
+			path = TypingScreenView;
+			sourceTree = "<group>";
+		};
 		7DCAA26A2A5F33D600AFC118 = {
 			isa = PBXGroup;
 			children = (
@@ -146,7 +157,7 @@
 		7DCAA2A62A5F33EC00AFC118 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				7DCAA2A72A5F340100AFC118 /* TypingScreenView.swift */,
+				7D76E1932A6FBC6E00D76E59 /* TypingScreenView */,
 				7DCAA2AA2A5FEC8800AFC118 /* KeyboardLayoutView.swift */,
 				7DCAA2AE2A5FF3CE00AFC118 /* TypingEditor.swift */,
 				7DCAA2B02A5FF5C700AFC118 /* HistoryUploadsView.swift */,
@@ -295,6 +306,7 @@
 				7DCAA2802A5F33D700AFC118 /* Persistence.swift in Sources */,
 				7DCAA2AF2A5FF3CE00AFC118 /* TypingEditor.swift in Sources */,
 				7DCAA2A82A5F340100AFC118 /* TypingScreenView.swift in Sources */,
+				7D76E1952A6FBC7F00D76E59 /* TypingScreenViewModel.swift in Sources */,
 				7DCAA2B12A5FF5C700AFC118 /* HistoryUploadsView.swift in Sources */,
 				7DCAA2772A5F33D600AFC118 /* TypingPallApp.swift in Sources */,
 				7DCAA2B42A60024A00AFC118 /* String+Utils.swift in Sources */,

--- a/TypingPall/Views/TypingScreenView/TypingScreenView.swift
+++ b/TypingPall/Views/TypingScreenView/TypingScreenView.swift
@@ -2,36 +2,28 @@ import SwiftUI
 
 struct TypingScreenView: View {
     @Environment(\.managedObjectContext) private var viewContext
-
-    @State private var editorText = ""
-    @State private var isShowingPlaceholderText = false
-    @State private var isShowingHistoryUploads = false
-    @State private var placeholderText = "This is a placeholder text for typing practice."
-    @State private var temPlaceholderText = "This is a placeholder text for typing practice."
-    @State private var lastKeyboardType: String?
-
-    @State private var redraw = false
+    @StateObject private var viewModel = TypingScreenViewModel()
 
     var body: some View {
         VStack {
             // Section 1: Text Editor
-            TypingEditor(text: $editorText, placeholder: $placeholderText)
+            TypingEditor(text: $viewModel.editorText, placeholder: $viewModel.placeholderText)
                 .frame(minWidth: 500, minHeight: 250)
                 .padding(.vertical)
                 .border(Color.gray, width: 1)
 
             // Section 2: Keyboard Layout
-            KeyboardLayoutView(typedLetter: $lastKeyboardType)
+            KeyboardLayoutView(typedLetter: $viewModel.lastKeyboardType)
                 .frame(minWidth: 500, minHeight: 250)
                 .border(Color.gray, width: 1)
         }
         .frame(minWidth: 500, minHeight: 50)
-        .onChange(of: editorText, perform: { newValue in
-            lastKeyboardType = newValue.last.flatMap { String($0) }
+        .onChange(of: viewModel.editorText, perform: { newValue in
+            viewModel.lastKeyboardType = newValue.last.flatMap { String($0) }
         })
-        .sheet(isPresented: $isShowingPlaceholderText) {
+        .sheet(isPresented: $viewModel.isShowingPlaceholderText) {
             VStack {
-                TextEditor(text: $temPlaceholderText)
+                TextEditor(text: $viewModel.temPlaceholderText)
                     .font(.headline)
                     .frame(minWidth: 600, minHeight: 300)
                     .padding(.vertical)
@@ -40,37 +32,37 @@ struct TypingScreenView: View {
 
                 HStack {
                     Button("Update!") {
-                        placeholderText = temPlaceholderText
-                        addItem(with: placeholderText)
-                        editorText = ""
-                        isShowingPlaceholderText.toggle()
+                        viewModel.placeholderText = viewModel.temPlaceholderText
+                        addItem(with: viewModel.placeholderText)
+                        viewModel.editorText = ""
+                        viewModel.isShowingPlaceholderText.toggle()
                     }
 
                     Spacer()
 
                     Button("Dismiss") {
-                        isShowingPlaceholderText.toggle()
+                        viewModel.isShowingPlaceholderText.toggle()
                     }
                 }
             }
             .padding(.all)
         }
-        .sheet(isPresented: $isShowingHistoryUploads) {
-            HistoryUploadsView(placeholderText: $placeholderText, isShowingHistoryUploads: $isShowingHistoryUploads)
+        .sheet(isPresented: $viewModel.isShowingHistoryUploads) {
+            HistoryUploadsView(placeholderText: $viewModel.placeholderText, isShowingHistoryUploads: $viewModel.isShowingHistoryUploads)
                 .frame(minWidth: 600, minHeight: 300)
         }
         .toolbar {
             ToolbarItem {
                 Button("Add text or code") {
-                    isShowingPlaceholderText = true
-                    temPlaceholderText = placeholderText
-                }.disabled(isShowingPlaceholderText)
+                    viewModel.isShowingPlaceholderText = true
+                    viewModel.temPlaceholderText = viewModel.placeholderText
+                }.disabled(viewModel.isShowingPlaceholderText)
             }
 
             ToolbarItem {
                 Button("History") {
-                    isShowingHistoryUploads = true
-                }.disabled(isShowingHistoryUploads)
+                    viewModel.isShowingHistoryUploads = true
+                }.disabled(viewModel.isShowingHistoryUploads)
             }
         }
     }

--- a/TypingPall/Views/TypingScreenView/TypingScreenViewModel.swift
+++ b/TypingPall/Views/TypingScreenView/TypingScreenViewModel.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+final class TypingScreenViewModel: ObservableObject {
+    @Published var editorText = ""
+    @Published var isShowingPlaceholderText = false
+    @Published var isShowingHistoryUploads = false
+    @Published var placeholderText = "This is a placeholder text for typing practice."
+    @Published var temPlaceholderText = "This is a placeholder text for typing practice."
+    @Published var lastKeyboardType: String?
+}


### PR DESCRIPTION
# Why

Simple refactoring 

# How

Changes included in this pull request:
- 14f9ab5 Simply Extract viewModel




