### PR TITLE
Update text colour when textDidChange(_:)

### DIFF
--- a/TypingPall/Views/Editor/Context.swift
+++ b/TypingPall/Views/Editor/Context.swift
@@ -3,6 +3,9 @@ import AppKit
 final class Coordinator: NSObject, NSTextViewDelegate {
     var parent: TypingEditor
 
+    private var textView: NSTextView { parent.typingTextView }
+    private var placeholderTextView: NSTextView { parent.placeholderTextView }
+
     init(_ parent: TypingEditor) {
         self.parent = parent
     }
@@ -17,6 +20,8 @@ final class Coordinator: NSObject, NSTextViewDelegate {
            !scrollView.visibleRect.contains(cursorPosition) {
             scrollView.scroll(cursorPosition)
         }
+
+        changeTextColorIfNeeded()
     }
 
     private func cursorPosition(in textView: NSTextView) -> NSPoint? {
@@ -30,5 +35,22 @@ final class Coordinator: NSObject, NSTextViewDelegate {
         rect.origin.y += textView.textContainerInset.height
 
         return rect.origin
+    }
+
+    func changeTextColorIfNeeded() {
+        guard !textView.string.isEmpty else { return }
+
+        let numberOfTypedCharacters = textView.string.count
+
+        guard let mismatchedRange = textView.string.extractMismatchedRange(comparedTo: placeholderTextView.string) else {
+            textView.setTextColor(.systemGreen, range: NSMakeRange(0, numberOfTypedCharacters))
+            return
+        }
+
+        if mismatchedRange.location > 1 {
+            textView.setTextColor(.systemGreen, range: NSMakeRange(0,  mismatchedRange.location - 1))
+        }
+
+        textView.setTextColor(.red, range: mismatchedRange)
     }
 }

--- a/TypingPall/Views/Editor/TypingEditor.swift
+++ b/TypingPall/Views/Editor/TypingEditor.swift
@@ -64,28 +64,10 @@ struct TypingEditor: NSViewRepresentable {
               let placeholderTextView = typingTextView.superview?.subviews.first as? NSTextView
         else { return }
 
-        typingTextView.string = text
         placeholderTextView.string = placeholder
-
-        changeTypingTextColorIfNeeded(typingTextView, placeholder: placeholder)
 
         typingTextView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .bold)
         placeholderTextView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .bold)
-    }
-
-    func changeTypingTextColorIfNeeded(_ textView: NSTextView, placeholder: String) {
-        guard !textView.string.isEmpty else { return }
-
-        guard let range = textView.string.extractMismatchedRange(comparedTo: placeholder) else {
-            textView.setTextColor(.systemGreen, range: NSMakeRange(0, textView.string.count))
-            return
-        }
-
-        if range.location > 1 {
-            textView.setTextColor(.systemGreen, range: NSMakeRange(0,  range.location - 1))
-        }
-
-        textView.setTextColor(.red, range: range)
     }
 }
 


### PR DESCRIPTION
Previously the text colour was modified in [`func updateNSView(_ nsView: NSView, context: Context)`](https://developer.apple.com/documentation/swiftui/nsviewrepresentable/updatensview(_:context:)) which is called multiple times during the state changes. However, the text colour only needs updates when the text changes.

This PR moves the text colour logic to NSTextDelegate [`func textDidChange(_ notification: Notification)`](https://developer.apple.com/documentation/appkit/nstextdelegate/1526982-textdidchange).