### PR TITLE
Hide the placeholder behind the typed characters

### DIFF
--- a/TypingPall/Views/Editor/Context.swift
+++ b/TypingPall/Views/Editor/Context.swift
@@ -38,9 +38,19 @@ final class Coordinator: NSObject, NSTextViewDelegate {
     }
 
     func changeTextColorIfNeeded() {
-        guard !textView.string.isEmpty else { return }
+        guard !textView.string.isEmpty else {
+            placeholderTextView.textColor = .placeholderTextColor
+            return
+        }
 
         let numberOfTypedCharacters = textView.string.count
+        let numberOfRemainingCharacters = placeholderTextView.string.count - numberOfTypedCharacters
+
+        if numberOfRemainingCharacters >= 0 {
+            // Hide the placeholder behind the typed characters
+            placeholderTextView.setTextColor(.clear, range: NSMakeRange(0, numberOfTypedCharacters))
+            placeholderTextView.setTextColor(.placeholderTextColor, range: NSMakeRange(numberOfTypedCharacters, numberOfRemainingCharacters))
+        }
 
         guard let mismatchedRange = textView.string.extractMismatchedRange(comparedTo: placeholderTextView.string) else {
             textView.setTextColor(.systemGreen, range: NSMakeRange(0, numberOfTypedCharacters))

--- a/TypingPall/Views/Editor/TypingEditor.swift
+++ b/TypingPall/Views/Editor/TypingEditor.swift
@@ -64,7 +64,12 @@ struct TypingEditor: NSViewRepresentable {
               let placeholderTextView = typingTextView.superview?.subviews.first as? NSTextView
         else { return }
 
-        placeholderTextView.string = placeholder
+        if placeholderTextView.string != placeholder {
+            // Reset the input text after updating the placeholder
+            placeholderTextView.textColor = .placeholderTextColor
+            placeholderTextView.string = placeholder
+            typingTextView.string = ""
+        }
 
         typingTextView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .bold)
         placeholderTextView.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .bold)


### PR DESCRIPTION
Not sure if it was a design decision, but the typed characters seem to overlap with the placeholder if they don't match.

This PR adds additional logic to hide the placeholder behind the typed characters. If showing both was the intended behaviour, please feel free to close this PR 🙏 

Before|After
---|---
<img src="https://github.com/Mieraidihaimu/TypingPall/assets/2032500/0b47ee58-8563-41f0-96b1-ae4c8e9c94b4.png" width="400" />|<img src="https://github.com/Mieraidihaimu/TypingPall/assets/2032500/be697ae3-2ea7-4c2b-96d4-d51af693c198.png" width="400" />
