### PR TITLE
Update the presented sheet buttons to the macOS convention

### DIFF
--- a/TypingPall/Views/TypingScreenView/TypingScreenView.swift
+++ b/TypingPall/Views/TypingScreenView/TypingScreenView.swift
@@ -34,18 +34,20 @@ struct TypingScreenView: View {
                     .padding(.all)
 
                 HStack {
-                    Button("Update!") {
+                    Spacer()
+
+                    Button("Cancel") {
+                        viewModel.isShowingPlaceholderText = false
+                    }
+                    .keyboardShortcut(.cancelAction)
+
+                    Button("Done") {
                         viewModel.placeholderText = viewModel.temPlaceholderText
                         addItem(with: viewModel.placeholderText)
                         viewModel.editorText = ""
                         viewModel.isShowingPlaceholderText.toggle()
                     }
-
-                    Spacer()
-
-                    Button("Dismiss") {
-                        viewModel.isShowingPlaceholderText.toggle()
-                    }
+                    .keyboardShortcut(.return, modifiers: [.command])
                 }
             }
             .padding(.all)


### PR DESCRIPTION
It's a macOS convention to have the buttons on the lower right corner in the order of `[cancel]-[confirm]`.

<img width="500" src="https://github.com/Mieraidihaimu/TypingPall/assets/2032500/96fc589d-f082-499f-9f69-d4ec87e77a2f">

I find it weird having to reach the lower left corner to update the text in the app.

This PR updates the UI layout to rearrange the buttons and add keyboard shortcuts:

- `Esc` to cancel
- `Cmd + return` to update the text

Before|After
---|---
<img src="https://github.com/Mieraidihaimu/TypingPall/assets/2032500/9108fdb3-772b-4770-83bc-3c6fff6e186b" width="400" />|<img src="https://github.com/Mieraidihaimu/TypingPall/assets/2032500/e0cc2e1f-4069-414d-9173-85616a72ec76" width="400" />
