### PR TITLE
Add Tap to spaces functionality in raw

### DIFF
--- a/TypingPall/Utils/String+Utils.swift
+++ b/TypingPall/Utils/String+Utils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 extension String {
     func extractMismatchedRange(comparedTo placeholder: String) -> NSRange? {

--- a/TypingPall/Utils/String+Utils.swift
+++ b/TypingPall/Utils/String+Utils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 extension String {
     func extractMismatchedRange(comparedTo placeholder: String) -> NSRange? {

--- a/TypingPall/Views/Editor/Context.swift
+++ b/TypingPall/Views/Editor/Context.swift
@@ -24,6 +24,15 @@ final class Coordinator: NSObject, NSTextViewDelegate {
         changeTextColorIfNeeded()
     }
 
+    func textView(_ textView: NSTextView, shouldChangeTextIn affectedCharRange: NSRange, replacementString: String?) -> Bool {
+        if replacementString == "\t" {
+            textView.insertText(Array(repeating: " ", count: Int(parent.spaces)).joined(), replacementRange: affectedCharRange)
+            return false
+        }
+
+        return true
+    }
+
     private func cursorPosition(in textView: NSTextView) -> NSPoint? {
         guard let textContainer = textView.textContainer,
               let layoutManager = textView.layoutManager else { return nil }

--- a/TypingPall/Views/Editor/TypingEditor.swift
+++ b/TypingPall/Views/Editor/TypingEditor.swift
@@ -6,6 +6,8 @@ struct TypingEditor: NSViewRepresentable {
     @Binding var placeholder: String
     var fontSize: CGFloat
 
+    @AppStorage("tabEqualsToSpaces") var spaces: Double = 4
+
     let placeholderTextView: NSTextView = {
         let textView = NSTextView()
         textView.textColor = NSColor.placeholderTextColor

--- a/TypingPall/Views/Setting/AppearanceSettingsView.swift
+++ b/TypingPall/Views/Setting/AppearanceSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AppearanceSettingsView: View {
     @AppStorage("typingFontSize") var typingFontSize: Double = 25.0
     @AppStorage("isShowingKeyboard") var isShowingKeyboard = false
+    @AppStorage("tabEqualsToSpaces") var spaces: Double = 4
 
     var body: some View {
         Form {
@@ -15,6 +16,13 @@ struct AppearanceSettingsView: View {
                     Text("Typing Font size")
                 }
             })
+
+            Slider(value: $spaces, in: 2...4, step: 2.0) {
+                VStack {
+                    Text("\(Int(spaces))")
+                    Text("Tabs equal to \(Int(spaces)) Spaces")
+                }
+            }
 
             Spacer()
         }

--- a/TypingPall/Views/TypingScreenView/TypingScreenView.swift
+++ b/TypingPall/Views/TypingScreenView/TypingScreenView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TypingScreenView: View {
     @Environment(\.managedObjectContext) private var viewContext
+
     @StateObject private var viewModel = TypingScreenViewModel()
 
     var body: some View {
@@ -42,9 +43,8 @@ struct TypingScreenView: View {
                     .keyboardShortcut(.cancelAction)
 
                     Button("Done") {
-                        viewModel.placeholderText = viewModel.temPlaceholderText
+                        viewModel.updatePlacholder(with: viewModel.temPlaceholderText)
                         addItem(with: viewModel.placeholderText)
-                        viewModel.editorText = ""
                         viewModel.isShowingPlaceholderText.toggle()
                     }
                     .keyboardShortcut(.return, modifiers: [.command])

--- a/TypingPall/Views/TypingScreenView/TypingScreenViewModel.swift
+++ b/TypingPall/Views/TypingScreenView/TypingScreenViewModel.swift
@@ -10,4 +10,10 @@ final class TypingScreenViewModel: ObservableObject {
 
     @AppStorage("typingFontSize") var textViewFontSize: Double = 25
     @AppStorage("isShowingKeyboard") var isShowingKeyboard = false
+    @AppStorage("tabEqualsToSpaces") private var spaces: Double = 4
+
+    func updatePlacholder(with text: String) {
+        placeholderText = text.replacingOccurrences(of: "\t", with: Array(repeating: " ", count: Int(spaces)).joined())
+        editorText = ""
+    }
 }


### PR DESCRIPTION
# Why

close https://github.com/Mieraidihaimu/TypingPall/issues/2

# How

Come up with a very brute force solution to introduce tab / spaces conversion.

Changes included in this pull request:
- 789addb Add Tap to Spaces functionality in Raw
- Add Setting UI element to change spacing from 4 to 2. 

# Screenshots


<img width="736" alt="Screenshot 2023-08-21 at 20 26 19" src="https://github.com/Mieraidihaimu/TypingPall/assets/10674364/497b6e08-618a-402e-a71f-129a6ee35b7c">

<img width="453" alt="Screenshot 2023-08-21 at 20 26 16" src="https://github.com/Mieraidihaimu/TypingPall/assets/10674364/874d6d2c-f3f0-43f5-a2bf-39ae0160674e">

